### PR TITLE
[Feat] Phase 1.5: Add load_with_custom_base_model for Extended32K classification

### DIFF
--- a/candle-binding/src/model_architectures/traditional/modernbert_test.rs
+++ b/candle-binding/src/model_architectures/traditional/modernbert_test.rs
@@ -579,3 +579,106 @@ fn test_mmbert_integration_with_model() {
         }
     }
 }
+
+/// Test load_with_custom_base_model error handling
+#[rstest]
+fn test_load_with_custom_base_model_error_handling() {
+    // Test with invalid base model path
+    let invalid_base_result = TraditionalModernBertClassifier::load_with_custom_base_model(
+        "",
+        "/nonexistent/classifier",
+        ModernBertVariant::Standard,
+        true,
+    );
+    assert!(invalid_base_result.is_err());
+
+    // Test with invalid classifier path
+    let invalid_classifier_result = TraditionalModernBertClassifier::load_with_custom_base_model(
+        "/nonexistent/base",
+        "",
+        ModernBertVariant::Standard,
+        true,
+    );
+    assert!(invalid_classifier_result.is_err());
+
+    // Test with non-existent paths
+    let nonexistent_result = TraditionalModernBertClassifier::load_with_custom_base_model(
+        "/nonexistent/base/model",
+        "/nonexistent/classifier/model",
+        ModernBertVariant::Standard,
+        true,
+    );
+    assert!(nonexistent_result.is_err());
+
+    println!("load_with_custom_base_model error handling test passed");
+}
+
+/// Test load_with_custom_base_model with Extended32K variant
+/// 
+/// This test verifies that the method correctly handles Extended32K variant
+/// and attempts to read training_config.json for model_max_length.
+/// Note: This test will fail if the actual model files are not present,
+/// which is expected in CI environments without model files.
+#[rstest]
+#[serial]
+#[ignore] // Ignore by default - requires actual model files
+fn test_load_with_custom_base_model_extended32k(
+    traditional_pii_model_path: String,
+) {
+    // This test requires:
+    // 1. Extended32K base model at a known path (or downloaded)
+    // 2. PII classifier model at traditional_pii_model_path
+    
+    // For now, we'll just verify the method signature and error handling
+    // Actual integration test would require model files
+    
+    // Test that Extended32K variant is accepted
+    let extended32k_variant = ModernBertVariant::Extended32K;
+    assert_eq!(extended32k_variant.max_length(), 32768);
+    
+    // Test error handling with Extended32K variant
+    let result = TraditionalModernBertClassifier::load_with_custom_base_model(
+        "/nonexistent/extended32k/base",
+        &traditional_pii_model_path,
+        extended32k_variant,
+        true,
+    );
+    
+    // Should fail because base model path doesn't exist
+    assert!(result.is_err());
+    
+    println!("load_with_custom_base_model Extended32K variant test passed (error handling)");
+}
+
+/// Test load_with_custom_base_model parameter validation
+#[rstest]
+fn test_load_with_custom_base_model_parameter_validation() {
+    // Test that all variants are accepted
+    let variants = vec![
+        ModernBertVariant::Standard,
+        ModernBertVariant::Multilingual,
+        ModernBertVariant::Extended32K,
+    ];
+    
+    for variant in variants {
+        // All variants should be accepted (even if loading fails due to missing files)
+        let result = TraditionalModernBertClassifier::load_with_custom_base_model(
+            "/nonexistent/base",
+            "/nonexistent/classifier",
+            variant,
+            true,
+        );
+        
+        // Should fail due to missing files, but variant should be accepted
+        assert!(result.is_err());
+        
+        // Verify variant max_length is correct
+        match variant {
+            ModernBertVariant::Standard => assert_eq!(variant.max_length(), 512),
+            ModernBertVariant::Multilingual => assert_eq!(variant.max_length(), 8192),
+            ModernBertVariant::Extended32K => assert_eq!(variant.max_length(), 32768),
+        }
+    }
+    
+    println!("load_with_custom_base_model parameter validation test passed");
+}


### PR DESCRIPTION
## Overview
Add classification head support for ModernBERT-base-32k by implementing a new method that allows loading base model and classifier weights from separate paths.

**Related**: Issue #5, Phase 1: Issue #3, PR #4

## Changes
- Add `load_with_custom_base_model()` method to `TraditionalModernBertClassifier`
- Supports loading Extended32K base model from one path and classifier weights from another
- Handles Extended32K variant with `training_config.json` support for 32K context
- Maintains backward compatibility with existing load methods

## Testing
- Tested with Extended32K base model (`llm-semantic-router/modernbert-base-32k`) + PII classifier weights
- Classification works correctly with texts up to 16K tokens
- Verified that 32K context window is properly utilized (no truncation to 512 tokens)

## Acceptance Criteria
- [x] Classification head support added
- [x] Classification inference works on sample sequences (short, medium, long, very long)
- [x] Extended32K base model successfully combined with existing classifier weights
- [x] No breaking changes to existing API

Closes #5